### PR TITLE
Long command-lines fixed

### DIFF
--- a/unpackbootimg.c
+++ b/unpackbootimg.c
@@ -131,7 +131,7 @@ int main(int argc, char** argv)
     printf("BOARD_RAMDISK_OFFSET %08x\n", header.ramdisk_addr - base);
     printf("BOARD_SECOND_OFFSET %08x\n", header.second_addr - base);
     printf("BOARD_TAGS_OFFSET %08x\n", header.tags_addr - base);
-    int a,b,c,y,m = 0;
+    int a=0, b=0, c=0, y=0, m=0;
     if (header.os_version != 0) {
         int os_version,os_patch_level;
         os_version = header.os_version >> 11;


### PR DESCRIPTION
From looking at the Android source code it looks like this is the correct way to handle long command-lines.  Mainly the _entire_ length of cmdline can be used if the command-line is longer, no nil-character is required in that field.  `unpackbootimg`'s behavior was completely missing the extra area.

Get a few uninitialized variables which show up if you try building with extra warnings on.