### PR TITLE
unpackbootimg: avoid unaligned memory access

### DIFF
--- a/unpackbootimg.c
+++ b/unpackbootimg.c
@@ -51,7 +51,8 @@ const char *detect_hash_type(boot_img_hdr_v2 *hdr)
      * sha1 is expected to have zeroes in id[5], id[6] and id[7]
      * Zeroes anywhere else probably indicates neither.
      */
-    const uint32_t *id = hdr->id;
+    uint32_t id[8];
+    memcpy(&id, hdr->id, sizeof(id));
     if (id[0] != 0 && id[1] != 0 && id[2] != 0 && id[3] != 0 &&
         id[4] != 0 && id[5] != 0 && id[6] != 0 && id[7] != 0) {
         return "sha256";


### PR DESCRIPTION
struct boot_img_hdr_v2 is packed, and referencing its member array can cause
unaligned memory access, leading to undefined behavior.

memcpy its content to the local array to avoid it.

This fixes the following warning on x86 and gcc-9.3.0:

unpackbootimg.c: In function ‘detect_hash_type’:
unpackbootimg.c:54:26: warning: taking address of packed member of ‘struct boot_img_hdr_v2’ may result in an unaligned pointer value [-Waddress-of-packed-member]
   54 |     const uint32_t *id = hdr->id;
      |                          ^~~

Signed-off-by: Park Ju Hyung <qkrwngud825@gmail.com>