### PR TITLE
unpackbootimg: Correct the output format of sizeof(header)

### DIFF
--- a/unpackbootimg.c
+++ b/unpackbootimg.c
@@ -296,7 +296,7 @@ int main(int argc, char **argv)
             write_string_to_file("hashtype", hash_type);
 
             total_read += sizeof(header);
-            if(debug>1){printf("read: %d\n", sizeof(header));}
+            if(debug>1){printf("read: %ld\n", sizeof(header));}
             total_read += read_padding(f, sizeof(header));
 
             write_buffer_to_file("kernel", f, header.kernel_size);
@@ -348,7 +348,7 @@ int main(int argc, char **argv)
             write_string_to_file("header_version", hdrvertmp);
 
             total_read += sizeof(header);
-            if(debug>1){printf("read: %d\n", sizeof(header));}
+            if(debug>1){printf("read: %ld\n", sizeof(header));}
             total_read += read_padding(f, sizeof(header));
 
             write_buffer_to_file("kernel", f, header.kernel_size);
@@ -415,7 +415,7 @@ int main(int argc, char **argv)
         write_string_to_file("dtb_offset", dtbofftmp);
 
         total_read += sizeof(header);
-        if(debug>1){printf("read: %d\n", sizeof(header));}
+        if(debug>1){printf("read: %ld\n", sizeof(header));}
         total_read += read_padding(f, sizeof(header));
 
         write_buffer_to_file("vendor_ramdisk", f, header.vendor_ramdisk_size);


### PR DESCRIPTION
The type returned by sizeof(header) is long unsigned int, and the output format is %d.
A format error will be returned when compiling. (error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘long unsigned int’)