### PR TITLE
mkbootimg: inform user about unknown argument

### DIFF
--- a/mkbootimg.c
+++ b/mkbootimg.c
@@ -358,6 +358,7 @@ int main(int argc, char **argv)
                     return -1;
                 }
             } else {
+                fprintf(stderr, "error: unknown argument '%s'\n", arg);
                 return usage();
             }
         } else {


### PR DESCRIPTION
Now the user will known which argument provided is invalid instead of
just getting the usage printed.