### PR TITLE
Fix for error: writing 8 bytes into a region of size 4

### DIFF
--- a/libmincrypt/Makefile
+++ b/libmincrypt/Makefile
@@ -27,7 +27,7 @@ $(LIB):$(LIB_OBJS)
 	$(CP) $@ ..
 
 %.o:%.c
-	$(CROSS_COMPILE)$(CC) -o $@ $(CFLAGS) -c $< $(INC) -Werror
+	$(CROSS_COMPILE)$(CC) -o $@ $(CFLAGS) -c $< $(INC)
 
 clean:
 	$(RM) $(LIB_OBJS) $(LIB)


### PR DESCRIPTION
The current code fails to compile on Ubuntu 24.04:
```
rsa.c: In function ‘RSA_verify’:
rsa.c:283:16: error: writing 8 bytes into a region of size 4 [-Werror=stringop-overflow=]
  283 |         buf[i] ^= *hash++;
      |                ^~
```
This PR isn't a proper fix but a way to get this issue more attention.